### PR TITLE
fix(ci): ajouter bean AnthropicChatModel stub pour le profil ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
           timeout_seconds: 10
           max_attempts: 6
           command: |
-            curl -fsS "$(minikube service ai-agent --url)/actuator/health"
+            URL=$(minikube service ai-agent --url 2>&1 | grep -oE 'https?://[^[:space:]]+' | head -1)
+            curl -fsS "${URL}/actuator/health"
 
       - name: Log pods on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,19 @@ jobs:
           minikube service list
 
       - name: Test service health endpoint
-        uses: nick-fields/retry@v3
-        with:
-          timeout_seconds: 10
-          max_attempts: 6
-          command: |
-            URL=$(minikube service ai-agent --url 2>&1 | grep -oE 'https?://[^[:space:]]+' | head -1)
-            curl -fsS "${URL}/actuator/health"
+        run: |
+          kubectl port-forward svc/ai-agent 8080:8080 &
+          PF_PID=$!
+          sleep 5
+          for i in $(seq 1 6); do
+            if curl -fsS http://127.0.0.1:8080/actuator/health; then
+              kill $PF_PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 2
+          done
+          kill $PF_PID 2>/dev/null || true
+          exit 1
 
       - name: Log pods on failure
         if: failure()

--- a/agent/src/main/java/com/example/agent/config/LangChainConfig.java
+++ b/agent/src/main/java/com/example/agent/config/LangChainConfig.java
@@ -15,6 +15,17 @@ import java.util.List;
 @Configuration
 public class LangChainConfig {
 
+    /** Stub for CI: app must start without a real API key so the pod becomes Ready. */
+    @Bean
+    @Profile("ci")
+    public AnthropicChatModel anthropicChatModelCi() {
+        return AnthropicChatModel.builder()
+                .apiKey("ci-placeholder-no-real-calls")
+                .modelName("claude-3-5-sonnet")
+                .timeout(Duration.ofSeconds(5))
+                .build();
+    }
+
     @Bean
     @Profile("!ci")
     public AnthropicChatModel anthropicChatModel(

--- a/agent/src/main/java/com/example/agent/mcp/McpHttpClient.java
+++ b/agent/src/main/java/com/example/agent/mcp/McpHttpClient.java
@@ -1,6 +1,7 @@
 package com.example.agent.mcp;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Component
+@Profile("!ci")
 public class McpHttpClient {
     private final WebClient web;
     private final String path;

--- a/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
+++ b/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
@@ -4,11 +4,13 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import com.example.agent.mcp.McpHttpClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 @Component
+@Profile("!ci")
 public class GitHubMcpTools implements AgentTool {
 
     private final McpHttpClient mcp;

--- a/agent/src/main/java/com/example/agent/web/TestController.java
+++ b/agent/src/main/java/com/example/agent/web/TestController.java
@@ -1,10 +1,12 @@
 package com.example.agent.web;
 
 import com.example.agent.tools.GitHubMcpTools;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile("!ci")
 @RestController
 @RequestMapping("/test")
 public class TestController {

--- a/agent/src/main/k8s/ai-agent-deployment.yml
+++ b/agent/src/main/k8s/ai-agent-deployment.yml
@@ -19,6 +19,10 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "ci"
+            - name: GITHUB_OWNER
+              value: "nfatousamb282"
+            - name: GITHUB_REPO
+              value: "lab_mcp_ai_agent_springboot"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/agent/src/main/resources/application.yml
+++ b/agent/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 github:
-  owner: ${GITHUB_OWNER}
-  repo: ${GITHUB_REPO}
+  owner: ${GITHUB_OWNER:ci-owner}
+  repo: ${GITHUB_REPO:ci-repo}
 
 anthropic:
   api-key: ${ANTHROPIC_API_KEY}


### PR DESCRIPTION
Permet au pod de démarrer en CI (SPRING_PROFILES_ACTIVE=ci) sans clé API réelle, évitant le timeout de kubectl wait sur le déploiement Minikube.

Made-with: Cursor